### PR TITLE
feat(Preference): Users should be able to like and dislike articles

### DIFF
--- a/authors/apps/articles/models.py
+++ b/authors/apps/articles/models.py
@@ -54,6 +54,10 @@ class Article(models.Model):
 
     tags = models.ManyToManyField(Tag, related_name='article_tag')
 
+    likes = models.ManyToManyField(User, related_name='like_preferences')
+
+    dislikes = models.ManyToManyField(User, related_name='dislike_preferences')
+
     def __str__(self):
         """
         :return: string
@@ -78,6 +82,35 @@ class Article(models.Model):
         """
         ratings = self.scores.all().aggregate(score=Avg("score"))
         return float('%.2f' % (ratings["score"] if ratings['score'] else 0))
+
+    def like(self, user):
+        return self.likes.add(user)
+
+    def dislike(self, user):
+        return self.dislikes.add(user)
+
+    def un_like(self, user):
+        return self.likes.remove(user)
+
+    def un_dislike(self, user):
+        return self.dislikes.remove(user)
+
+    def is_liking(self, user):
+        return self.likes.filter(pk=user.pk).exists()
+
+    def is_disliking(self, user):
+        return self.dislikes.filter(pk=user.pk).exists()
+
+    def is_neutral(self, user):
+        return not self.likes.filter(pk=user.pk).exists() and not self.dislikes.filter(pk=user.pk).exists()
+
+    def like_to_dislike(self, user):
+        self.un_like(user)
+        self.dislike(user)
+
+    def dislike_to_like(self, user):
+        self.un_dislike(user)
+        self.like(user)
 
     class Meta:
         get_latest_by = 'created_at'

--- a/authors/apps/articles/preference_utils.py
+++ b/authors/apps/articles/preference_utils.py
@@ -1,0 +1,64 @@
+from rest_framework.response import Response
+from authors.apps.articles.exceptions import NotFoundException
+from .models import Article
+
+
+def return_article(slug):
+    """ This method returns the article with the provided slug """
+    try:
+        article = Article.objects.get(slug__exact=slug)
+        return article
+    except Article.DoesNotExist:
+        raise NotFoundException("Article is not found.")
+
+
+def make_first_preference_attempt(action, slug, current_user):
+    """ Called when user is liking or disliking for the first time """
+
+    article = return_article(slug)
+    if action == "like":
+        article.like(current_user)
+        article.save()
+        message = {"message": "You like this article"}
+        return Response(message)
+    article.dislike(current_user)
+    article.save()
+    return Response({"message": "You dislike this article"})
+
+
+def change_preference(action, slug, current_user):
+    """ This method is called when user wants to make a change to the preference"""
+
+    article = return_article(slug)
+
+    if action == "like":
+
+        # User likes the article
+        if article.is_disliking(current_user):
+            article.dislike_to_like(current_user)
+            return Response({"message": "You now like this article"})
+
+        # current user is re liking
+        article.un_like(current_user)
+        return Response({"message": "You no longer like this article"})
+
+    # action is a dislike
+    if article.is_liking(current_user):
+        article.like_to_dislike(current_user)
+        return Response({"message": "You now dislike this article"})
+
+    # current user is re disliking
+    article.un_dislike(current_user)
+    return Response({"message": "You no longer dislike this article"})
+
+
+def call_preference_helpers(action, slug, current_user):
+    """ Called with in the post methods to call other helper function
+        To like, unlike, dislike and un_dislike an article
+    """
+
+    article = return_article(slug)
+    if article.is_neutral(current_user):
+        return make_first_preference_attempt(action, slug, current_user)
+    return change_preference(action, slug, current_user)
+

--- a/authors/apps/articles/serializers.py
+++ b/authors/apps/articles/serializers.py
@@ -149,6 +149,9 @@ class ArticleSerializer(serializers.ModelSerializer):
         response['author'] = profile
         return response
 
+    likes = serializers.SerializerMethodField()
+    dislikes = serializers.SerializerMethodField()
+
     class Meta:
         """
         class behaviours
@@ -156,10 +159,16 @@ class ArticleSerializer(serializers.ModelSerializer):
         model = Article
 
         fields = ('slug', 'title', 'description', 'body', 'created_at', 'average_rating', 'user_rating',
-                  'updated_at', 'favorites_count', 'photo_url', 'author', 'tagList', 'comments')
+                  'updated_at', 'favorites_count', 'photo_url', 'author', 'tagList', 'comments', 'likes', 'dislikes')
 
     def get_favorites_count(self, instance):
         return instance.favorited_by.count()
+
+    def get_likes(self, instance):
+        return instance.likes.all().count()
+
+    def get_dislikes(self, instance):
+        return instance.dislikes.all().count()
 
 
 class PaginatedArticleSerializer(PageNumberPagination):

--- a/authors/apps/articles/tests/test_like_or_dislike.py
+++ b/authors/apps/articles/tests/test_like_or_dislike.py
@@ -1,0 +1,154 @@
+from django.test import TestCase
+from rest_framework.test import APIClient
+from authors.apps.articles.models import User
+import json
+
+
+class LikeOrDislikeTestCase(TestCase):
+    def setUp(self):
+        self.client = APIClient()
+
+        # create first user
+        self.first_user = User.objects.create_user(
+            "username_one", "first_email@gmail.com", "password"
+        )
+        self.first_user = User.objects.get(email="first_email@gmail.com")
+        self.first_user.is_active = True
+        self.first_user.is_email_verified = True
+        self.first_user.save()
+
+        # create second user
+        self.second_user = User.objects.create_user(
+            "username_two", "second_email@gmail.com", "password"
+        )
+        self.second_user = User.objects.get(email="second_email@gmail.com")
+        self.second_user.is_active = True
+        self.second_user.is_email_verified = True
+        self.second_user.save()
+
+        # create_third user
+        self.third_user = User.objects.create_user(
+            "username_three", "third_email@gmail.com", "password"
+        )
+        self.third_user = User.objects.get(email="third_email@gmail.com")
+        self.third_user.is_active = True
+        self.third_user.is_email_verified = True
+        self.third_user.save()
+
+        # Login first user
+        self.login_first = self.client.post("/api/users/login/",
+                                            data={"user": {
+                                                "email": "first_email@gmail.com",
+                                                "password": "password",
+                                                }
+                                            },
+                                            format="json")
+
+        # Login second user
+        self.login_second = self.client.post("/api/users/login/",
+                                            data={"user": {
+                                                "email": "second_email@gmail.com",
+                                                "password": "password",
+                                                }
+                                            },
+                                            format="json")
+
+        # Login third user
+        self.login_third = self.client.post("/api/users/login/",
+                                            data={"user": {
+                                                "email": "third_email@gmail.com",
+                                                "password": "password",
+                                                }
+                                            },
+                                            format="json")
+        self.post_article = {
+            "article": {
+                "title": "Yet another Sand Blog",
+                "description": "Sand is m testing",
+                "body": "another that am doin test"
+            }
+        }
+
+        self.first_like = {"message": "You like this article"}
+        self.re_like = {"message": "You no longer like this article"}
+
+        self.first_dislike = {"message": "You dislike this article"}
+        self.re_dislike = {"message": "You no longer dislike this article"}
+
+        self.like_to_dislike = {'message': 'You now dislike this article'}
+        self.dislike_to_like = {'message': 'You now like this article'}
+
+        self.article_404 = {'detail': 'Article is not found.'}
+
+    def test_like_or_dislike_article(self):
+        token = self.login_first.data['token']
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + token)
+        response = self.client.post(
+            "/api/articles/", data=json.dumps(
+                self.post_article), content_type='application/json')
+        self.assertEqual(201, response.status_code)
+        self.assertIn('article', response.json())
+        self.assertIsInstance(response.json().get("article"), dict)
+
+        # get slug from created article
+        self.slug = response.json()['article']['slug']
+
+        # let username_one like this article
+        self.first_like_response = self.client.post("/api/articles/{}/like/".format(self.slug))
+        self.assertEqual(self.first_like_response.json(), self.first_like)
+
+        # let username_one re like this article
+        self.first_like_response = self.client.post("/api/articles/{}/like/".format(self.slug))
+        self.assertEqual(self.first_like_response.json(), self.re_like)
+
+        # Let username_two like this article
+        token = self.login_second.data['token']
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + token)
+        self.second_like_response = self.client.post("/api/articles/{}/like/".format(self.slug))
+        self.assertEqual(self.second_like_response.json(), self.first_like)
+
+        # lets username_two dislike the article he previously liked
+        self.first_like_response = self.client.post("/api/articles/{}/dislike/".format(self.slug))
+        self.assertEqual(self.first_like_response.json(), self.like_to_dislike)
+
+        # Let username_two re dislike this article
+        self.first_like_response = self.client.post("/api/articles/{}/dislike/".format(self.slug))
+        self.assertEqual(self.first_like_response.json(), self.re_dislike)
+
+        # lets username_two dislike the article | remember it is in the default state
+        self.first_like_response = self.client.post("/api/articles/{}/dislike/".format(self.slug))
+        self.assertEqual(self.first_like_response.json(), self.first_dislike)
+
+        # Let username_two like the article he previously disliked
+        self.second_like_response = self.client.post("/api/articles/{}/like/".format(self.slug))
+        self.assertEqual(self.second_like_response.json(), self.dislike_to_like)
+
+        token = self.login_third.data['token']
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + token)
+        self.third_like_response = self.client.post("/api/articles/{}/like/".format(self.slug))
+        self.assertEqual(self.third_like_response.json(), self.first_like)
+
+        # let username_three re-like this article
+        token = self.login_third.data['token']
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + token)
+        self.third_like_response = self.client.post("/api/articles/{}/like/".format(self.slug))
+        self.assertEqual(self.third_like_response.json(), self.re_like)
+
+        # Let username_three try to like an article that does not exist
+        token = self.login_third.data['token']
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + token)
+        self.third_like_response = self.client.post("/api/articles/404/like/")
+        self.assertEqual(self.third_like_response.json(), self.article_404)
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/authors/apps/articles/urls.py
+++ b/authors/apps/articles/urls.py
@@ -4,9 +4,12 @@ Defines urls used in article package
 from django.urls import path
 from rest_framework.routers import DefaultRouter
 
+
 from authors.apps.articles.views import (FavoriteArticlesAPIView,
                                          ArticleViewSet, TagViewSet, RatingsView, ArticleReportView,
-                                         CommentsView, RepliesView)
+                                         CommentsView, RepliesView,
+                                         DislikeOrUndislikeAPIView, LikeOrUnlikeAPIView)
+
 
 urlpatterns = [
 
@@ -22,8 +25,13 @@ urlpatterns = [
     path('comment/replies/<Id>/', RepliesView.as_view()),
 
     path("<slug>/rate/", RatingsView.as_view()),
+
     path("reports/", ArticleReportView.as_view()),
     path("reports/<slug>/", ArticleReportView.as_view()),
+
+    path("<slug>/like/", LikeOrUnlikeAPIView.as_view()),
+    path("<slug>/dislike/", DislikeOrUndislikeAPIView.as_view()),
+
 ]
 
 router = DefaultRouter()

--- a/authors/apps/articles/utils.py
+++ b/authors/apps/articles/utils.py
@@ -60,3 +60,4 @@ def generate_slug(cls, self):
         temp_slug = slugify(temp_slug + "-" + create_unique_number())
 
     return temp_slug
+

--- a/authors/apps/articles/views.py
+++ b/authors/apps/articles/views.py
@@ -6,6 +6,7 @@ from rest_framework import status, viewsets
 from rest_framework.exceptions import NotFound
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.views import APIView
+from rest_framework.response import Response
 from rest_framework.viewsets import ViewSet
 from authors.apps.articles.exceptions import (
     NotFoundException, InvalidQueryParameterException)
@@ -14,6 +15,13 @@ from authors.apps.articles.renderer import ArticleJSONRenderer, TagJSONRenderer
 from authors.apps.articles.serializers import (RatingSerializer, ArticleReportSerializer,
                                                ArticleSerializer, PaginatedArticleSerializer, TagSerializer)
 from authors.apps.articles.permissions import IsSuperuser
+
+from .preference_utils import call_preference_helpers
+
+from .views_extra import *
+
+
+# noinspection PyUnusedLocal,PyMethodMayBeStatic
 
 
 class ArticleViewSet(ViewSet):
@@ -237,8 +245,6 @@ class TagViewSet(viewsets.ModelViewSet):
             {"message": "tag deleted successfuly"}, status=status.HTTP_204_NO_CONTENT)
 
 
-from .views_extra import *
-
 class ArticleReportView(APIView):
     """
     Handles creating, reading, updating and deleting reports
@@ -283,3 +289,21 @@ class ArticleReportView(APIView):
             return Response({"reports": serializer.data}, status=status.HTTP_200_OK)
         return Response({"detail": "permission denied, you do not have access rights."},
                         status=status.HTTP_403_FORBIDDEN)
+
+
+class LikeOrUnlikeAPIView(APIView):
+    """ Implement liking an article """
+
+    permission_classes = (IsAuthenticated,)
+
+    def post(self, request, slug):
+        return call_preference_helpers("like", slug, request.user)
+
+
+class DislikeOrUndislikeAPIView(LikeOrUnlikeAPIView):
+    """ Implement disliking an article """
+
+    def post(self, request, slug):
+        return call_preference_helpers("dislike", slug, request.user)
+
+


### PR DESCRIPTION
**What does this PR do?** 
   - It enables users to like and dislike articles.

**Description of Tasks to be completed?**
Have the following endpoints working

`POST /api/articles/`
 `Get /api/articles/`
`POST /api/articles/<slug>/like/`
`POST /api/articles/<slug>/dislike/`

**How should this be manually tested?**
- After cloning the repo, cd into the directory. 
- Run ```pip install -r requirements.txt```
- Use Postman to try out the endpoints.

Only authenticated users are allowed to access the above end points. So supply the token in the header 
- To like or dislike an article try the following end points. Remember to supply the article's slug in the URL.

`POST /api/articles/<slug>/like/`
`POST /api/articles/<slug>/dislike/`

- Now confirm that it working by listing these article. Take a look at the likes / dislike count
`POST /api/articles/`

**What are the relevant pivotal tracker stories?**

- [ #159952009](https://www.pivotaltracker.com/story/show/159952009)   
